### PR TITLE
Enhancement: Move all docker and docker compose dependencies to a separate folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,8 @@
 /tests
 
 # docker configuration files
-Dockerfile
-docker-compose.yml
+docker/Dockerfile
+docker/docker-compose.yml
 
 # environments
 .env


### PR DESCRIPTION
Fixes #35

Move docker dependencies to a separate folder.

* Update `.dockerignore` to reference `docker/Dockerfile` and `docker/docker-compose.yml` instead of the root directory files.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vcwild/wildoverflow/pull/36?shareId=8be546be-e08e-404b-9011-b80442b426b0).